### PR TITLE
#4 - Icons wrapper in root of library

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Icon variants are:
 
 There are two ways to import an icon based on your prefered type and variant.
 
-```ts
+```tsx
 // Outlined variant
 import { Search } from '@nine-thirty-five/material-symbols-react/outlined';
 import { Home } from '@nine-thirty-five/material-symbols-react/outlined/filled';
@@ -62,7 +62,7 @@ import { Login } from '@nine-thirty-five/material-symbols-react/sharp/filled';
 
 Icon component support all props that a React SVG component supports.
 
-```ts
+```tsx
 // Sample props
 <Search className="yourClassName" />
 <Home style={{fill: 'red'}} />
@@ -71,6 +71,22 @@ Icon component support all props that a React SVG component supports.
 <Delete fill='red' />
 <Login viewBox='0 0 24 24' />
 ```
+
+## Using icon wrapper
+
+The icon wrapper is a component that internally decides which icon variant to display using the `variant` and `filled` props.
+
+```tsx
+// Outlined variant
+import { Search, Home, Star } from '@nine-thirty-five/material-symbols-react';
+
+// Sample props
+<Search variant="outlined" className="yourClassName" />
+<Home variant="sharp" style={{fill: 'red'}} />
+<Star variant="sharp" size='1rem' filled />
+```
+
+> Note: the wrappers support the `size` prop, which sets both the height and width simultaneously.
 
 ## License
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -5,7 +5,9 @@ import {
   readFilesRecursively,
   filterExcludeIndexFile,
   parseFileForIndexGeneration,
+  generateIconWrapper,
 } from './generate.utils';
+import path from 'path';
 
 const nullIcons: string[] = [];
 
@@ -41,7 +43,16 @@ async function main() {
     `
     import { SVGProps } from 'react';
 
-    export type IconProps = SVGProps<SVGSVGElement>;
+    export type Variant = 'outlined' | 'sharp' | 'rounded';
+
+    export type IconProps = SVGProps<SVGSVGElement> & {
+      size?: number | string;
+    };
+
+    export type IconWrapperProps = IconProps & {
+      variant?: Variant;
+      filled?: boolean;
+    };
     `
   );
 
@@ -68,6 +79,20 @@ async function main() {
       `./icons/${variant}/filled/index.tsx`
     );
   }
+
+  // GENERATE icons wrappers
+  const outlinedFiles = readFilesRecursively('./icons/outlined', '.tsx');
+  const outlinedFiltered = filterExcludeIndexFile(outlinedFiles);
+  const fileNames = outlinedFiltered.map((p) => path.basename(p, '.tsx'));
+
+  for (const name of fileNames) {
+    await generateIconWrapper(name, './icons');
+  }
+
+  await generateIndexFile(
+    outlinedFiltered.map(parseFileForIndexGeneration),
+    `./icons/index.tsx`
+  );
 
   // Log null icons
   console.log('Null icon urls', nullIcons);

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -3,6 +3,8 @@ import {
   generateIndexFile,
   generateIconVariant,
   readFilesRecursively,
+  filterExcludeIndexFile,
+  parseFileForIndexGeneration,
 } from './generate.utils';
 
 const nullIcons: string[] = [];
@@ -48,13 +50,10 @@ async function main() {
 
   for (const variant of variants) {
     const files = readFilesRecursively(`./icons/${variant}`, '.tsx');
+    const filesFiltered = filterExcludeIndexFile(files);
+
     await generateIndexFile(
-      files.map((path) => {
-        return {
-          path: `./${path.split('/').at(-1)?.split('.')[0] ?? ''}`,
-          name: path.split('/').at(-1)?.split('.')[0] ?? '',
-        };
-      }),
+      filesFiltered.map(parseFileForIndexGeneration),
       `./icons/${variant}/index.tsx`
     );
 
@@ -62,13 +61,10 @@ async function main() {
       `./icons/${variant}/filled`,
       '.tsx'
     );
+    const filledFiltered = filterExcludeIndexFile(filledFiles);
+
     await generateIndexFile(
-      filledFiles.map((path) => {
-        return {
-          path: `./${path.split('/').at(-1)?.split('.')[0] ?? ''}`,
-          name: path.split('/').at(-1)?.split('.')[0] ?? '',
-        };
-      }),
+      filledFiltered.map(parseFileForIndexGeneration),
       `./icons/${variant}/filled/index.tsx`
     );
   }

--- a/src/generate.utils.ts
+++ b/src/generate.utils.ts
@@ -331,3 +331,27 @@ export function readFilesRecursively(
 
   return files;
 }
+
+export function filterExcludeIndexFile(files: string[]): string[] {
+  return files.filter((file) => {
+    const posix = file.replace(/\\/g, '/');
+    return path.basename(posix) !== 'index.tsx';
+  });
+}
+
+export function parseFileForIndexGeneration(file: string): {
+  name: string;
+  path: string;
+} {
+  const posix = file.replace(/\\/g, '/');
+  const name = posix.substring(
+    posix.lastIndexOf('/') + 1,
+    posix.lastIndexOf('.')
+  );
+  const relPath = `./${name}`;
+
+  return {
+    name,
+    path: relPath,
+  };
+}

--- a/src/generate.utils.ts
+++ b/src/generate.utils.ts
@@ -332,6 +332,31 @@ export function readFilesRecursively(
   return files;
 }
 
+export async function generateIconWrapper(name: string, outputDir: string) {
+  const pascal = toPascalCase(convertNumbersToWords(name));
+  const wrapper = `
+  import React from 'react'
+  import { IconWrapperProps } from './types'
+
+  export const ${pascal} = ({ variant = 'outlined', filled, ...props }: IconWrapperProps) => {
+    const importPath = \`./\${variant}\${filled ? "/filled" : ""}/${pascal}\`;
+
+    const LazyIcon = React.useMemo(
+      () => React.lazy(() => import(importPath)),
+      [importPath]
+    )
+
+    return (
+      <React.Suspense fallback={null}>
+        <LazyIcon {...props} />
+      </React.Suspense>
+    )
+  }
+  export default ${pascal}
+  `.trim();
+  await fs.promises.writeFile(path.join(outputDir, `${pascal}.tsx`), wrapper);
+}
+
 export function filterExcludeIndexFile(files: string[]): string[] {
   return files.filter((file) => {
     const posix = file.replace(/\\/g, '/');


### PR DESCRIPTION
- **fix: index generation on Windows**
  Normalize path separators when generating icon indexes on Windows to ensure `index.tsx` is created correctly.
- **add: icons wrapper in root of library**
  Introduce root-level “wrapper” components for every icon.
  - Expose `variant` and `filled` props to dynamically select which SVG to render.
  - Use `React.lazy` + `Suspense` for code-splitting so only the requested variant is loaded.
  - Add a new `size` prop that simultaneously sets both `height` and `width`.
- **docs: update readme.md**
  Update the README with usage examples for the new icon wrappers.

> Note: I included the `size` prop without prior discussion. Would you prefer I remove it, or do you think it’s a useful addition? Feedback welcome!